### PR TITLE
TT-32: Fix status row not translated for vac/sick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Fixed being unable to toggle easymode
 
+<!-- The status row for both Sickness and Vacation reports is now translated -->
+
 ## v7.3
 
 * Toil API release `v1.8` now supports loading custom routes. Read more about this feature in the `api/v1/toil/README.md` file.

--- a/api/v1/class/i18n/admin/worktime/sick/all/snippets_DE.json
+++ b/api/v1/class/i18n/admin/worktime/sick/all/snippets_DE.json
@@ -5,5 +5,13 @@
     "t1": "Mitarbeiter",
     "t2": "Krankheit Beginn",
     "t3": "Krankheit Ende",
-    "t4": "Status"
+    "t4": "Status",
+    "status": {
+        "set_to": "Setzen zu",
+        "pending": "In Prüfung",
+        "or": "oder",
+        "approved": "Genehmigt",
+        "rejected": "Abgelehnt",
+        "not_found": "Keine Krankheiten vorhanden."
+    }
 }

--- a/api/v1/class/i18n/admin/worktime/sick/all/snippets_EN.json
+++ b/api/v1/class/i18n/admin/worktime/sick/all/snippets_EN.json
@@ -5,5 +5,13 @@
     "t1": "Employee",
     "t2": "Sickness Start",
     "t3": "Sickness End",
-    "t4": "Status"
+    "t4": "Status",
+    "status": {
+        "set_to": "Set to",
+        "pending": "Pending",
+        "or": "or",
+        "approved": "Approved",
+        "rejected": "Rejected",
+        "not_found": "No sickness records found."
+    }
 }

--- a/api/v1/class/i18n/admin/worktime/vacation/all/snippets_DE.json
+++ b/api/v1/class/i18n/admin/worktime/vacation/all/snippets_DE.json
@@ -5,5 +5,13 @@
     "t1": "Mitarbeiter",
     "t2": "Urlaub Beginn",
     "t3": "Urlaub Ende",
-    "t4": "Status"
+    "t4": "Status",
+    "status": {
+        "set_to": "Setzen zu",
+        "pending": "In Prüfung",
+        "or": "oder",
+        "approved": "Genehmigt",
+        "rejected": "Abgelehnt",
+        "not_found": "Keine Urlaubsdatensätze gefunden."
+    }
 }

--- a/api/v1/class/i18n/admin/worktime/vacation/all/snippets_EN.json
+++ b/api/v1/class/i18n/admin/worktime/vacation/all/snippets_EN.json
@@ -5,5 +5,12 @@
     "t1": "Employee",
     "t2": "Vacation Start",
     "t3": "Vacation End",
-    "t4": "Status"
+    "t4": "Status",
+    "status": {
+        "set_to": "Set to",
+        "pending": "Pending",
+        "or": "or",
+        "approved": "Approved",
+        "rejected": "Rejected"
+    }
 }

--- a/api/v1/class/sickness/sickness.arbeit.inc.php
+++ b/api/v1/class/sickness/sickness.arbeit.inc.php
@@ -62,6 +62,8 @@ namespace Arbeitszeit {
         }
 
         public function display_sickness_all(){ # admin function only
+            $i18n = $this->i18n()->loadLanguage(null, "worktime/sick/all", "admin");
+            
             $sql = "SELECT * FROM `sick` LIMIT 100;";
             $data = $this->db()->sendQuery($sql);
             $data->execute();
@@ -78,10 +80,10 @@ namespace Arbeitszeit {
 
                     switch($status){
                         case "pending":
-                            $status = "<span style='color:yellow;'>pending</span>";
+                            $status = "<span style='color:yellow;'>{$i18n["status"]["pending"]}</span>";
                             break;
                         case "approved":
-                            $status = "<span style='color:green;'>approved</span>";
+                            $status = "<span style='color:green;'>{$i18n["status"]["approved"]}</span>";
                             break;
                         case "action":
                             $status = "<span style='color:red'>Action needed</span>";
@@ -98,7 +100,7 @@ namespace Arbeitszeit {
                             <td>{$rnw}</td>
                             <td>{$start}</td>
                             <td>{$stop}</td>
-                            <td>{$status} | Set to <a href="/suite/admin/actions/worktime/state_sickness.php?id={$id}&new=pending&u={$rnw}">Pending</a> or <a href="/suite/admin/actions/worktime/state_sickness.php?id={$id}&new=approve&u={$rnw}">Approved</a> or <a href="/suite/admin/actions/worktime/state_sickness.php?id={$id}&new=reject&u={$rnw}">Rejected</a></td></td>
+                            <td>{$status} | {$i18n["status"]["set_to"]} <a href="/suite/admin/actions/worktime/state_sickness.php?id={$id}&new=pending&u={$rnw}">{$i18n["status"]["pending"]}</a> {$i18n["status"]["or"]} <a href="/suite/admin/actions/worktime/state_sickness.php?id={$id}&new=approve&u={$rnw}">{$i18n["status"]["approved"]}</a> {$i18n["status"]["or"]} <a href="/suite/admin/actions/worktime/state_sickness.php?id={$id}&new=reject&u={$rnw}">{$i18n["status"]["rejected"]}</a></td></td>
                         </tr>
 
 
@@ -107,7 +109,7 @@ namespace Arbeitszeit {
                     echo $print;
                 }
             } else {
-                return "Keine Krankheiten eingetragen.";
+                return $i18n["status"]["not_found"];
             }
         }
 

--- a/api/v1/class/vacation/vacation.arbeit.inc.php
+++ b/api/v1/class/vacation/vacation.arbeit.inc.php
@@ -87,6 +87,8 @@ namespace Arbeitszeit {
         }
 
         public function display_vacation_all(){ # admin function only
+            $i18n = $this->i18n()->loadLanguage(null, "worktime/vacation/all", "admin");
+            
             $sql = "SELECT * FROM `vacation`";
             $data = $this->db->sendQuery($sql);
             $data->execute();
@@ -102,13 +104,13 @@ namespace Arbeitszeit {
 
                     switch($status){
                         case "pending":
-                            $status = "<span style='color:yellow;'>pending</span>";
+                            $status = "<span style='color:yellow;'>{$i18n["status"]["pending"]}</span>";
                             break;
                         case "approved":
-                            $status = "<span style='color:green;'>approved</span>";
+                            $status = "<span style='color:green;'>{$i18n["status"]["approved"]}</span>";
                             break;
                         case "rejected":
-                            $status = "<span style='color:red'>rejected</span>";
+                            $status = "<span style='color:red'>{$i18n["status"]["rejected"]}</span>";
                             break;
                     }
 
@@ -122,7 +124,7 @@ namespace Arbeitszeit {
                             <td>{$rnw}</td>
                             <td>{$start}</td>
                             <td>{$stop}</td>
-                            <td>{$status} | Set to <a href="/suite/admin/actions/worktime/state_vacation.php?id={$id}&new=pending&u={$rnw}">Pending</a> or <a href="/suite/admin/actions/worktime/state_vacation.php?id={$id}&new=approve&u={$rnw}">Approved</a> or <a href="/suite/admin/actions/worktime/state_vacation.php?id={$id}&new=reject&u={$rnw}">Rejected</a></td>
+                            <td>{$status} | {$i18n["status"]["set_to"]} <a href="/suite/admin/actions/worktime/state_vacation.php?id={$id}&new=pending&u={$rnw}">{$i18n["status"]["pending"]}</a> {$i18n["status"]["or"]} <a href="/suite/admin/actions/worktime/state_vacation.php?id={$id}&new=approve&u={$rnw}">{$i18n["status"]["approved"]}</a> {$i18n["status"]["or"]} <a href="/suite/admin/actions/worktime/state_vacation.php?id={$id}&new=reject&u={$rnw}">{$i18n["status"]["rejected"]}</a></td>
                         </tr>
 
 
@@ -132,7 +134,7 @@ namespace Arbeitszeit {
                 }
             } else {
                 Exceptions::error_rep("[VACATION] No vacations found. Returning.");
-                return "Keine Urlaube eingetragen.";
+                return $i18n["status"]["not_found"];
             }
         }
 


### PR DESCRIPTION
* The status row for both Sickness and Vacation reports is now translated