### PR TITLE
TT-51: Allow custom CSS for PDF exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Renamed all GUI elements from `Calendar` to `Notifications`
 * Fixed being unable to edit notifications entries
 * PDF and CSV exports are now directly saved onto the server. This is done automatically. Exports are saved within `data/exports/{ExportModuleName}/{username}/`
+* CSS for PDF exports can now be customized. You can specify your own CSS file within the `app.ini` `[exports][pdf][css]` setting (full path)
 
 <!-- Fixed title not set for Plugin Hub -->
 <!-- Fixed missing i18n files for `suite/admin/notifications/edit.php` -->

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ $arbeit->exportModule()->getExportModule("MyExportExportModule")->export($data);
 ```
 
 As there is currently no Export Area in the UI you have to create the GUI elements on your own.
+You can specify your own CSS file within the `app.ini` `[exports][pdf][css]` setting (full path) - the default is `api/v1/class/exports/modules/PDFExportModule/css/index.css`
 
 ## Updates
 

--- a/api/v1/class/exports/modules/PDFExportModule/PDFExportModule.em.arbeit.inc.php
+++ b/api/v1/class/exports/modules/PDFExportModule/PDFExportModule.em.arbeit.inc.php
@@ -30,25 +30,17 @@ class PDFExportModule implements ExportModuleInterface {
             }
             $user_data = Benutzer::get_user($user);
             $user_data["name"] ?? $statement->fetch(\PDO::FETCH_ASSOC)[0]["name"]; # Bug 14 Fix -> http://bugzilla.openducks.org/show_bug.cgi?id=14
-
+            try {
+                $css = @file_get_contents($ini["exports"]["pdf"]["css"]);
+            } catch (\ValueError $e) {
+                $css = file_get_contents(__DIR__ . "/css/index.css");
+            }
             $data = <<< DATA
             <html>
                 <body style="text-align:center; font-family: Arial;">
                     <h1>{$i18nn["worktime_note"]} <b>{$user_data["name"]}</b></h1>
                     <style>
-                        .box {
-                            width: auto;
-                            max-width: 900px;
-                            height: auto;
-                            border: 5px solid;
-                            padding: auto;
-                            margin: auto;
-                            border-radius: 5px;
-                            margin-left: auto;
-                            margin-right: auto;
-                            opacity: 1;
-                            border-color: rgba(255,255,255,0.64);
-                            transition: all 0.5s;
+                        $css
                     </style>
                     <div class="box">
                         <table style="width:100%;border:solid;">

--- a/api/v1/class/exports/modules/PDFExportModule/css/index.css
+++ b/api/v1/class/exports/modules/PDFExportModule/css/index.css
@@ -1,0 +1,14 @@
+.box {
+    width: auto;
+    max-width: 900px;
+    height: auto;
+    border: 5px solid;
+    padding: auto;
+    margin: auto;
+    border-radius: 5px;
+    margin-left: auto;
+    margin-right: auto;
+    opacity: 1;
+    border-color: rgba(255,255,255,0.64);
+    transition: all 0.5s;
+}


### PR DESCRIPTION
* CSS for PDF exports can now be customized. You can specify your own CSS file within the `app.ini` `[exports][pdf][css]` setting (full path)