### PR TITLE
TT-52: Allow registering and removing API routes via class functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * **Replaced `app.ini` with `app.json`**. The `app.ini` has been deprecated and will be removed within the `8.0` release. Your settings will be automatically migrated to the new `app.json` file.
 * Added plugin to clock in with QR codes. This plugin is disabled by default and can be enabled within the `plugins.yml`. More information can be found inside the `README.md`.
+* You can now register or remove a custom API route via the `CustomRoutes::registerCustomRoute(...)` or `CustomRoutes::removeCustomRoute(...)` functions. More information can be found inside the Toil API `/api/v1/toil/README.md`.
 
 ## v7.5
 

--- a/api/v1/toil/CustomRoutes.routes.toil.arbeit.inc.php
+++ b/api/v1/toil/CustomRoutes.routes.toil.arbeit.inc.php
@@ -14,6 +14,30 @@ namespace Toil {
 
         }
 
+        public static function registerCustomRoute($endpoint, $classFile, $permissions = 0){
+            $file = json_decode(file_get_contents($_SERVER["DOCUMENT_ROOT"] . "/data/routes/routes.json"), true);
+            $file[$endpoint] = $classFile;
+            file_put_contents($_SERVER["DOCUMENT_ROOT"] . "/data/routes/routes.json", json_encode($file, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+            $permissionsFile = json_decode(file_get_contents(__DIR__ . "/permissions.json"), true);
+            $permissionsFile[$endpoint] = $permissions;
+            file_put_contents(__DIR__ . "/permissions.json", json_encode($permissionsFile, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+            
+            return true;
+        }
+
+        public static function removeCustomRoute($endpoint){
+            $file = json_decode(file_get_contents($_SERVER["DOCUMENT_ROOT"] . "/data/routes/routes.json"), true);
+            unset($file->$endpoint);
+            file_put_contents($_SERVER["DOCUMENT_ROOT"] . "/data/routes/routes.json", json_encode($file, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+            $permissionsFile = json_decode(file_get_contents(__DIR__ . "/permissions.json"), true);
+            unset($permissionsFile->$endpoint);
+            file_put_contents(__DIR__ . "/permissions.json", json_encode($permissionsFile, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+            
+            return true;
+        }
+
         public static function loadCustomRoute($endpoint, $classFile, $method = "GET"){
             Router::get("/api/v1/toil/" . $endpoint, function() use ($endpoint, $classFile){
                 Exceptions::error_rep("[API] User authenticated and accessing custom API endpoint '{$endpoint}'");
@@ -29,6 +53,7 @@ namespace Toil {
                     if($route == "_comment"){continue;}
                     Exceptions::error_rep("[API] Loading custom API route '{$route}'");
                     self::loadCustomRoute($route, $class);
+                    echo var_dump($route, $class);
                 } catch (\Throwable $e){
                     Exceptions::error_rep("[API] Could not load custom API route. Message: " . $e->getMessage() . " | Code: " . $e->getCode() . " | Trace (if available): " . $e->getTraceAsString());
                 }
@@ -36,6 +61,4 @@ namespace Toil {
         }
     }
 }
-
-
 ?>

--- a/api/v1/toil/CustomRoutes.routes.toil.arbeit.inc.php
+++ b/api/v1/toil/CustomRoutes.routes.toil.arbeit.inc.php
@@ -53,7 +53,6 @@ namespace Toil {
                     if($route == "_comment"){continue;}
                     Exceptions::error_rep("[API] Loading custom API route '{$route}'");
                     self::loadCustomRoute($route, $class);
-                    echo var_dump($route, $class);
                 } catch (\Throwable $e){
                     Exceptions::error_rep("[API] Could not load custom API route. Message: " . $e->getMessage() . " | Code: " . $e->getCode() . " | Trace (if available): " . $e->getTraceAsString());
                 }

--- a/api/v1/toil/README.md
+++ b/api/v1/toil/README.md
@@ -64,3 +64,12 @@ class EP extends Toil {
 }
 
 ```
+
+## Registering a route via function
+
+You can use the `CustomRoutes::registerCustomRoute("myRoute", "/api/v1/toil/resources/myRoute.ep.toil.arbeit.inc.php", 1)` - `CustomRoutes::registerCustomRoute(string $endpoint, string $classFile, int $permissions)` function to register a custom route. If `$permissions = 1` only admins can access the endpoint.
+
+## Removing a route via function
+
+You can use the `CustomRoutes::removeCustomRoute("myRoute")` function to deregister a custom route.
+This also removes the permissions from the `permissions.json` file.


### PR DESCRIPTION
* You can now register or remove a custom API route via the `CustomRoutes::registerCustomRoute(...)` or `CustomRoutes::removeCustomRoute(...)` functions. More information can be found inside the Toil API `/api/v1/toil/README.md`.