### PR TITLE
TT-77: Allow dump of all included files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 <!-- Fixed missing API route for Codeclock plugin. -->
 <!-- PluginBuilder is now able to return the plugin configuration in raw YAML -->
+<!-- You can now dump all included files by setting "debug" to true within the app.ini -->
 
 ## v7.6
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ In step 2, you need to configure the `app.ini.sample`/`app.json.sample` within t
 - `app_name`: The name of your application, e.g. `ACME Inc. TimeRecording`
 - `base_url`: The Base URL (can also be an IP) of your application, without ending trailing slash and the protocol, e.g. `acme.inc` or `10.10.10.2` (URLs will be built with the http:// protocol, we recommend adding a redirect to https:// if you use an certificate.)
 - `support_email`: An email displayed to users in case of help, e.g. `support@acme.inc`
-- `debug`: (deprecated)
+- `debug`: (deprecated, but may still unlock certain functionality)
 - `auto_update`: (not yet implemented)
 - `db_*`: Set the connection details for your mysql instance
 - `app`: If set to true, users will be able to use the TimeTrack mobile application

--- a/api/v1/class/arbeitszeit.inc.php
+++ b/api/v1/class/arbeitszeit.inc.php
@@ -54,6 +54,12 @@ namespace Arbeitszeit {
             $this->init_lang() ?? null;
         }
 
+        public function __destruct(){
+            if (self::get_app_ini()["general"]["debug"] == true || self::get_app_ini()["general"]["debug"] == "false") {
+                Exceptions::error_rep("Destroying Arbeitszeit class, dump of all loaded files: " . json_encode(get_included_files(), JSON_PRETTY_PRINT));
+            }
+        }
+
         public function init_lang()
         {
             $n = new i18n;


### PR DESCRIPTION
* Allow dump of all included files. Required `[general][debug]` to be set to `true` within app.ini to work