### PR TITLE
TT-187: Support multiple worktime types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v7.13
+
+* You can now set different types of worktimes. You can specify your own ones in the `app/v1/inc/configs/worktime_types.json` file. If none is set, like when using the easymode, mode `0` will be used.
+* Toil API release `1.12`: added Bearer token authentication
+
 ## v7.12.1
 
 * Updated `README.md`

--- a/api/v1/class/exports/modules/CSVExportModule/CSVExportModule.em.arbeit.inc.php
+++ b/api/v1/class/exports/modules/CSVExportModule/CSVExportModule.em.arbeit.inc.php
@@ -24,7 +24,7 @@ class CSVExportModule implements ExportModuleInterface
             $year = date("Y");
         }
 
-        $sql = "SELECT id, username, schicht_tag, schicht_anfang, schicht_ende, ort, pause_start, pause_end 
+        $sql = "SELECT id, username, schicht_tag, schicht_anfang, schicht_ende, ort, pause_start, pause_end, Wtype
                 FROM `arbeitszeiten` 
                 WHERE YEAR(schicht_tag) = ? AND MONTH(schicht_tag) = ? AND username = ? 
                 ORDER BY schicht_tag DESC";
@@ -47,7 +47,7 @@ class CSVExportModule implements ExportModuleInterface
         $output = fopen('php://output', 'w');
 
         // Set columns
-        $columns = ["ID", "Username", "Shift Date", "Shift Start", "Shift End", "Location/Notes", "Pause Start", "Pause End"];
+        $columns = ["ID", "Username", "Shift Date", "Shift Start", "Shift End", "Location/Notes", "Pause Start", "Pause End", "Type"];
         fputcsv($output, $columns, ';');
 
         // Datenzeilen in CSV schreiben
@@ -69,7 +69,7 @@ class CSVExportModule implements ExportModuleInterface
             $year = date("Y");
         }
     
-        $sql = "SELECT id, username, schicht_tag, schicht_anfang, schicht_ende, ort, pause_start, pause_end 
+        $sql = "SELECT id, username, schicht_tag, schicht_anfang, schicht_ende, ort, pause_start, pause_end, Wtype 
                 FROM `arbeitszeiten` 
                 WHERE YEAR(schicht_tag) = ? AND MONTH(schicht_tag) = ? AND username = ? 
                 ORDER BY schicht_tag DESC";
@@ -91,7 +91,7 @@ class CSVExportModule implements ExportModuleInterface
     
         $output = fopen($filename, 'w');
 
-        $columns = ["ID", "Username", "Shift Date", "Shift Start", "Shift End", "Location/Notes", "Pause Start", "Pause End"];
+        $columns = ["ID", "Username", "Shift Date", "Shift Start", "Shift End", "Location/Notes", "Pause Start", "Pause End", "Type"];
         fputcsv($output, $columns, ';');
     
         foreach ($data as $row) {

--- a/api/v1/class/exports/modules/PDFExportModule/PDFExportModule.em.arbeit.inc.php
+++ b/api/v1/class/exports/modules/PDFExportModule/PDFExportModule.em.arbeit.inc.php
@@ -51,6 +51,7 @@ class PDFExportModule implements ExportModuleInterface {
                                 <th>{$i18nn["pbegin"]}</th>
                                 <th>{$i18nn["pend"]}</th>
                                 <th>{$i18nn["loc"]}</th>
+                                <th>{$i18nn["type"]}</th>
                             </tr>
 
             DATA;
@@ -68,6 +69,7 @@ class PDFExportModule implements ExportModuleInterface {
                     $rew = $row["schicht_anfang"];
                     $rol = $row["schicht_ende"];
                     $ral = $row["ort"];
+                    $rtn = $arbeit->type_from_int($row["Wtype"]) ?? "N/A";
                     $rps = @strftime("%H:%M", strtotime($row["pause_start"]));
                     $rpe = @strftime("%H:%M", strtotime($row["pause_end"]));
 
@@ -88,6 +90,7 @@ class PDFExportModule implements ExportModuleInterface {
                                 <td>{$rps}</td>
                                 <td>{$rpe}</td>
                                 <td>{$ral}</td>
+                                <td>{$rtn}</td>
                             </tr>
 
 

--- a/api/v1/class/i18n/admin/worktime/all/snippets_DE.json
+++ b/api/v1/class/i18n/admin/worktime/all/snippets_DE.json
@@ -12,5 +12,6 @@
     "send": "Schicht Ende",
     "pbegin": "Pause Start",
     "pend": "Pause Ende",
-    "loc": "Ort"
+    "loc": "Ort",
+    "type": "Typ"
 }

--- a/api/v1/class/i18n/admin/worktime/all/snippets_EN.json
+++ b/api/v1/class/i18n/admin/worktime/all/snippets_EN.json
@@ -12,5 +12,6 @@
     "send": "end of shift",
     "pbegin": "Break Start",
     "pend": "end of break",
-    "loc": "location"
+    "loc": "location",
+    "type": "type"
 }

--- a/api/v1/class/i18n/admin/worktime/all/snippets_NL.json
+++ b/api/v1/class/i18n/admin/worktime/all/snippets_NL.json
@@ -12,5 +12,6 @@
     "send": "einde dienst",
     "pbegin": "Breekstart",
     "pend": "einde einde",
-    "loc": "locatie"
+    "loc": "locatie",
+    "type": "type"
 }

--- a/api/v1/class/i18n/suite/class/arbeitszeit/snippets_DE.json
+++ b/api/v1/class/i18n/suite/class/arbeitszeit/snippets_DE.json
@@ -7,5 +7,6 @@
     "csv": "(CSV)",
     "delete_entry": "Eintrag löschen",
     "no_shifts": "Keine Einträge gefunden.",
-    "or": "oder"
+    "or": "oder",
+    "type": "Typ"
 }

--- a/api/v1/class/i18n/suite/class/arbeitszeit/snippets_EN.json
+++ b/api/v1/class/i18n/suite/class/arbeitszeit/snippets_EN.json
@@ -7,5 +7,6 @@
     "csv": "(CSV)",
     "delete_entry": "Delete entry",
     "no_shifts": "No entries found.",
-    "or": "or"
+    "or": "or",
+    "type": "Type"
 }

--- a/api/v1/class/i18n/suite/class/arbeitszeit/snippets_NL.json
+++ b/api/v1/class/i18n/suite/class/arbeitszeit/snippets_NL.json
@@ -7,5 +7,6 @@
     "csv": "(CSV)",
     "delete_entry": "Invoer verwijderen",
     "no_shifts": "Geen vermeldingen gevonden.",
-    "or": "of"
+    "or": "of",
+    "type": "Type"
    }

--- a/api/v1/class/i18n/suite/class/pdf/snippets_DE.json
+++ b/api/v1/class/i18n/suite/class/pdf/snippets_DE.json
@@ -9,5 +9,6 @@
     "no_data": "Keine Daten gefunden!",
     "worktime_all": "Arbeitszeit insgesamt (gerundet)",
     "worktime_date": "Anfangsdatum der Daten",
-    "end_date": "Enddatum"
+    "end_date": "Enddatum",
+    "type": "Typ"
 }

--- a/api/v1/class/i18n/suite/class/pdf/snippets_EN.json
+++ b/api/v1/class/i18n/suite/class/pdf/snippets_EN.json
@@ -9,5 +9,6 @@
     "no_data": "No data found!",
     "worktime_all": "Total working time (rounded)",
     "worktime_date": "Start date of the data",
-    "end_date": "End date"
+    "end_date": "End date",
+    "type": "Type"
 }

--- a/api/v1/class/i18n/suite/class/pdf/snippets_NL.json
+++ b/api/v1/class/i18n/suite/class/pdf/snippets_NL.json
@@ -9,5 +9,6 @@
     "no_data": "Geen gegevens gevonden!",
     "worktime_all": "Totale werktijd (afgerond)",
     "worktime_date": "Begindatum van gegevens",
-    "end_date": "Einddatum"
+    "end_date": "Einddatum",
+    "type": "Type"
    }

--- a/api/v1/class/i18n/suite/mode/easymode/snippets_DE.json
+++ b/api/v1/class/i18n/suite/mode/easymode/snippets_DE.json
@@ -18,5 +18,6 @@
     "pend": "Pause Ende",
     "submit": "Absenden",
     "h_vacation": "Buche deinen Urlaub",
-    "h_sickness": "Krankheit eintragen"
+    "h_sickness": "Krankheit eintragen",
+    "type": "Typ"
 }

--- a/api/v1/class/i18n/suite/mode/easymode/snippets_EN.json
+++ b/api/v1/class/i18n/suite/mode/easymode/snippets_EN.json
@@ -18,5 +18,6 @@
     "pend": "end of break",
     "submit": "Send",
     "h_vacation": "Request vacation",
-    "h_sickness": "Report sickness"
+    "h_sickness": "Report sickness",
+    "type": "Type"
 }

--- a/api/v1/class/i18n/suite/mode/easymode/snippets_NL.json
+++ b/api/v1/class/i18n/suite/mode/easymode/snippets_NL.json
@@ -18,5 +18,6 @@
     "pend": "einde einde",
     "submit": "Verzenden",
     "h_vacation": "Boek uw vakantie",
-    "h_sickness": "Voer ziekte in"
+    "h_sickness": "Voer ziekte in",
+    "type": "Type"
    }

--- a/api/v1/class/i18n/suite/worktime/all/snippets_DE.json
+++ b/api/v1/class/i18n/suite/worktime/all/snippets_DE.json
@@ -6,5 +6,6 @@
     "s_end": "Schicht Ende",
     "s_pstart": "Pause Start",
     "s_pend": "Pause Ende",
-    "s_location": "Ort"
+    "s_location": "Ort",
+    "type": "Typ"
 }

--- a/api/v1/class/i18n/suite/worktime/all/snippets_EN.json
+++ b/api/v1/class/i18n/suite/worktime/all/snippets_EN.json
@@ -6,5 +6,6 @@
     "s_end": "Shift End",
     "s_pstart": "Pause Start",
     "s_pend": "Pause End",
-    "s_location": "Location"
+    "s_location": "Location",
+    "type": "Type"
 }

--- a/api/v1/class/i18n/suite/worktime/all/snippets_NL.json
+++ b/api/v1/class/i18n/suite/worktime/all/snippets_NL.json
@@ -6,5 +6,6 @@
     "s_end": "Einde dienst",
     "s_pstart": "Start pauzeren",
     "s_pend": "Einde einde",
-    "s_location": "Locatie"
+    "s_location": "Locatie",
+    "type": "Type"
 }

--- a/api/v1/class/mode/mode.arbeit.inc.php
+++ b/api/v1/class/mode/mode.arbeit.inc.php
@@ -16,6 +16,14 @@ namespace Arbeitszeit {
             }
         }
 
+        public static function compute_html_worktime_types(){
+            $data = "";
+            foreach(Arbeitszeit::get_all_types() as $type => $value){
+                $data .= "<option value=\"{$type}\">{$value}</option>";
+            }
+            return $data;
+        }
+
 
         private static function get_normal_mode_html(){
             $nodes = new Nodes;
@@ -24,6 +32,7 @@ namespace Arbeitszeit {
             }
             $i18n = new i18n;
             $loc = $i18n->loadLanguage(null, "mode/easymode");
+            $t = self::compute_html_worktime_types();
             $data = <<< DATA
             <form action="actions/worktime/add.php" method="POST">
             <label name="ort">{$loc["loc"]}</label>
@@ -43,6 +52,11 @@ namespace Arbeitszeit {
                 <br>
                 <label name="pause_end">{$loc["pend"]}</label>
                 <input class="input" type="time" name="pause_end" placeholder="{$loc["pend"]}">
+                <br>
+                <label name="Wtype">{$loc["type"]}</label>
+                <select class="input" name="Wtype">
+                    {$t}
+                </select>
                 <br>
                 <input class="input" type="text" name="username" value="{$_SESSION["username"]}" hidden>
                 <button type="submit" class="button">{$loc["submit"]}</button>

--- a/api/v1/inc/app.json.sample
+++ b/api/v1/inc/app.json.sample
@@ -46,5 +46,10 @@
         "saf_group": "GROUP",
         "saf_domain": "DOMAIN",
         "create_user": "true"
+    },
+    "config": {
+        "worktime_types": "/api/v1/inc/config/worktime_types.json",
+        "vacation_types": "/api/v1/inc/config/vacation_types.json",
+        "sickness_types": "/api/v1/inc/config/sickness_types.json"
     }
 }

--- a/api/v1/inc/config/worktime_types.json
+++ b/api/v1/inc/config/worktime_types.json
@@ -1,0 +1,7 @@
+{
+    "0": "Home Office",
+    "1": "Office",
+    "2": "Public Holiday",
+    "3": "Business Trip",
+    "4": "Mobile / On the Go"
+}

--- a/migrations/migrations/20250514181409_add_worktime_type_row.php
+++ b/migrations/migrations/20250514181409_add_worktime_type_row.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class AddWorktimeTypeRow extends AbstractMigration
+{
+
+    public function change(): void
+    {
+        if (!$this->table('arbeitszeiten')->hasColumn('Wtype')) {
+            $this->table('arbeitszeiten')
+            ->addColumn('Wtype', 'enum', [
+                'values' => ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'],
+                'default' => '0',
+                'null' => false,
+                'after' => 'pause_end'
+            ])
+            ->update();
+            $this->execute('UPDATE arbeitszeiten SET Wtype = "0" WHERE type IS NULL');
+            echo "Added Wtype column to arbeitszeiten table\n";
+        } else {
+            echo "Wtype column already exists in arbeitszeiten table\n";
+        }
+    }
+}

--- a/suite/actions/worktime/add.php
+++ b/suite/actions/worktime/add.php
@@ -4,7 +4,7 @@ use Arbeitszeit\Arbeitszeit;
 $worktime = new Arbeitszeit;
 $base_url = $worktime->get_app_ini()["general"]["base_url"];
 $worktime->auth()->login_validation();
-$work = $worktime->add_worktime($_POST["time_start"], $_POST["time_end"], $_POST["ort"], $_POST["date"], $_POST["username"],"worktime", array("start" => $_POST["pause_start"], "end" => $_POST["pause_end"]));
+$work = $worktime->add_worktime($_POST["time_start"], $_POST["time_end"], $_POST["ort"], $_POST["date"], $_POST["username"],"worktime", $_POST["Wtype"], array("start" => $_POST["pause_start"], "end" => $_POST["pause_end"]));
 if(!$work){
     header("Location: http://{$base_url}/suite/?info=error_worktime");
 } else {

--- a/suite/admin/worktime/all.php
+++ b/suite/admin/worktime/all.php
@@ -48,6 +48,7 @@ if(!is_string(@$_POST["jahr"]) || !is_string(@$_POST["monat"])){
                     <th><?php echo $loc["pbegin"] ?></th>
                     <th><?php echo $loc["pend"] ?></th>
                     <th><?php echo $loc["loc"] ?></th>
+                    <th><?php echo $loc["type"] ?></th>
                 </tr>
 
                 <?php echo $arbeit->get_specific_worktime_html($date_month, $date_year)  ?>

--- a/suite/worktime/all.php
+++ b/suite/worktime/all.php
@@ -36,6 +36,7 @@ if(!isset($_GET["monat"])){
                     <th><?php echo $loc["s_pstart"] ?></th>
                     <th><?php echo $loc["s_pend"] ?></th>
                     <th><?php echo $loc["s_location"] ?></th>
+                    <th><?php echo $loc["type"] ?></th>
                 </tr>
 
                 <?php echo $arbeit->get_employee_worktime_html($_SESSION["username"]);  ?>


### PR DESCRIPTION
* You can now set different types of worktimes. You can specify your own ones in the `app/v1/inc/configs/worktime_types.json` file. If none is set, like when using the easymode, mode `0` will be used.