### PR TITLE
Fix parameter order when adding worktime via Toil API

### DIFF
--- a/api/v1/toil/resources/addOwnWorktime.ep.toil.arbeit.inc.php
+++ b/api/v1/toil/resources/addOwnWorktime.ep.toil.arbeit.inc.php
@@ -45,7 +45,7 @@ namespace Toil {
             ];
 
             
-                if ($arbeit->add_worktime($data["start"], $data["end"], $data["location"], $data["date"], $data["username"], $data["type"], $data["pause"], $data["meta"])) {
+                if ($arbeit->add_worktime($data["start"], $data["end"], $data["location"], $data["date"], $data["username"], $data["type"], 0, $data["pause"], $data["meta"])) {
                     echo json_encode(["note" => "Successfully saved worktime record"]);
                 } else {
                     echo json_encode(["error" => "An error occured while saving worktime"]);

--- a/api/v1/toil/resources/addWorktime.ep.toil.arbeit.inc.php
+++ b/api/v1/toil/resources/addWorktime.ep.toil.arbeit.inc.php
@@ -45,7 +45,7 @@ namespace Toil {
             ];
 
             if ($user->is_admin($user->get_user($_SERVER["PHP_AUTH_USER"])) == true) {
-                if ($arbeit->add_worktime($data["start"], $data["end"], $data["location"], $data["date"], $data["username"], $data["type"], $data["pause"], $data["meta"])) {
+                if ($arbeit->add_worktime($data["start"], $data["end"], $data["location"], $data["date"], $data["username"], $data["type"], 0, $data["pause"], $data["meta"])) {
                     echo json_encode(["note" => "Successfully saved worktime record"]);
                 } else {
                     echo json_encode(["error" => "An error occured while saving worktime"]);


### PR DESCRIPTION
## Summary
- fix wrong parameter order in Toil's `addWorktime` and `addOwnWorktime` endpoints

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68409a7a3f8c83219959f9361846969d