### PR TITLE
TT-221

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Added automatic update check within the Settings page allowing to see the changelogs and a link to the new Release.
 * Updated `README.md`
+* Admins can now select the default worktime type to be selected in the form within the app.json `config` section via the `default_worktime_type` key.
+* Added function to automatically add keys to app.json after update
 
 ## v8.6
 

--- a/api/v1/class/arbeitszeit.inc.php
+++ b/api/v1/class/arbeitszeit.inc.php
@@ -60,6 +60,7 @@ namespace Arbeitszeit {
             if (isset($this->get_app_ini()["general"]["timezone"])) {
                 try {
                     date_default_timezone_set($this->get_app_ini()["general"]["timezone"]);
+                    $this->app_ini_check();
                 } catch (\Exception $e) {
                     Exceptions::error_rep("Error setting timezone: " . $e->getMessage());
                 }
@@ -72,6 +73,42 @@ namespace Arbeitszeit {
                 Exceptions::error_rep("Destroying Arbeitszeit class, dump of all loaded files: " . json_encode(get_included_files(), JSON_PRETTY_PRINT));
             }
         }
+
+        public function app_ini_check()
+        {
+            $base = dirname(__DIR__, 3) . "/api/v1/inc/";
+            $sample = json_decode(file_get_contents($base . "app.json.sample"), true);
+            $current = json_decode(file_get_contents($base . "app.json"), true);
+
+            $updated = false;
+
+            foreach ($sample as $section => $values) {
+
+                if (!isset($current[$section]) || !is_array($current[$section])) {
+                    $current[$section] = [];
+                    $updated = true;
+                    Exceptions::error_rep("App config section '{$section}' was missing and has been created.");
+                }
+
+                foreach ($values as $key => $value) {
+                    if (!array_key_exists($key, $current[$section])) {
+                        $current[$section][$key] = $value;
+                        $updated = true;
+                        Exceptions::error_rep(
+                            "App config key '{$key}' in section '{$section}' was missing and added with default value."
+                        );
+                    }
+                }
+            }
+
+            if ($updated) {
+                file_put_contents(
+                    $base . "app.json",
+                    json_encode($current, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+                );
+            }
+        }
+
 
         public function init_lang()
         {
@@ -128,8 +165,8 @@ namespace Arbeitszeit {
                 return false;
             } else {
                 Exceptions::error_rep("Creating easymode worktime entry for user '{$username}'...");
-                $sql = "INSERT INTO `arbeitszeiten` (`name`, `id`, `email`, `username`, `schicht_tag`, `schicht_anfang`, `schicht_ende`, `ort`, `active`, `review`) VALUES ( ?, '0', ?, ?, ?, ?, '00:00', '-', '1', '0');";
-                $data = $conn->sendQuery($sql)->execute([$usr["name"], $usr["email"], $username, $date, $time]);
+                $sql = "INSERT INTO `arbeitszeiten` (`name`, `id`, `email`, `username`, `schicht_tag`, `schicht_anfang`, `schicht_ende`, `ort`, `active`, `review`, `wtype`) VALUES ( ?, '0', ?, ?, ?, ?, '00:00', '-', '1', '0', ?);";
+                $data = $conn->sendQuery($sql)->execute([$usr["name"], $usr["email"], $username, $date, $time, Arbeitszeit::get_app_ini()["config"]["default_worktime_type"]]);
                 if ($data == false) {
                     Exceptions::error_rep("An error occurred while creating easymode worktime entry. See previous message for more information");
                     return false;
@@ -915,7 +952,7 @@ namespace Arbeitszeit {
                 $text .= "<strong>Changelog for version {$current}:</strong><br>";
                 $parsedown = new \Parsedown();
                 $currentChanges = $this->getChanges($current);
-                if($currentChanges == null) {
+                if ($currentChanges == null) {
                     $currentChanges["body"] = "**No changelogs found. Either you are using a custom build or something went wrong while fetching the changelogs.**";
                 }
                 $text .= $parsedown->text($currentChanges["body"]);

--- a/api/v1/class/mode/mode.arbeit.inc.php
+++ b/api/v1/class/mode/mode.arbeit.inc.php
@@ -21,8 +21,15 @@ namespace Arbeitszeit {
         public static function compute_html_worktime_types()
         {
             $data = "";
+            $selected = "";
             foreach (Arbeitszeit::get_all_types() as $type => $value) {
-                $data .= "<option value=\"{$type}\">{$value}</option>";
+                $selected = "";
+
+                if((int)$type == Arbeitszeit::get_app_ini()["config"]["default_worktime_type"]) {
+                    $selected = " selected";
+                }
+                print_r($type);
+                $data .= "<option value=\"{$type}\"{$selected}>{$value}</option>";
             }
             return $data;
         }

--- a/api/v1/inc/app.json.sample
+++ b/api/v1/inc/app.json.sample
@@ -55,7 +55,8 @@
     "config": {
         "worktime_types": "/api/v1/inc/config/worktime_types.json",
         "vacation_types": "/api/v1/inc/config/vacation_types.json",
-        "sickness_types": "/api/v1/inc/config/sickness_types.json"
+        "sickness_types": "/api/v1/inc/config/sickness_types.json",
+        "default_worktime_type": 1
     },
     "mobile": {
         "allow_app_use": false,


### PR DESCRIPTION
* Admins can now select the default worktime type to be selected in the form within the app.json `config` section via the `default_worktime_type` key.
* Added function to automatically add keys to app.json after update

closes TT-221
closes TT-222