### PR TITLE
v8.7.2: fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## 8.7.2
+
+> This will be the last release for the 8.x branch. The next release will be 9.0 which will include a new feature called `Worktime Governance` which will allow to set rules for worktimes, e.g. maximum worktime per day, minimum break time, etc. The feature is still in development and will be released as soon as it is ready.
+
+* Fixed an issue with the password reset email that would not display correctly.
+* Fixed incorrect use of the `SentEmail` event for any sent emails.
+* Fixed an issue with the `PluginHub` which caused certain pages to be blocked. Now admins can access these again. This issue only affected the `userdetail` plugin.
+* Fixed an issue with the `nfcclock` plugin which caused it to not fire any events.
+* The items page for project items now displays the user's name instead of the ID.
+
 ## v8.7.1
 
 * Fixed issues regarding XSS vulnerabilities on several pages.

--- a/api/v1/class/i18n/admin/projects/admin/snippets_EN.json
+++ b/api/v1/class/i18n/admin/projects/admin/snippets_EN.json
@@ -1,6 +1,6 @@
 {
     "title": "Projects - Admin",
-    "existing_projects": "Below is a list for which projects you are a member in.",
+    "existing_projects": "Below is a list for all projects you are a member in.",
     "th_id": "ID",
     "th_name": "Name",
     "th_deadline": "Deadline",

--- a/api/v1/class/i18n/suite/emails/password_reset/snippets_DE.json
+++ b/api/v1/class/i18n/suite/emails/password_reset/snippets_DE.json
@@ -1,7 +1,7 @@
 {
     "subject": "Deine Anfrage zum Zurücksetzen deines Passwortes",
     "greetings": "Hallo",
-    "message": "wir haben deine Anfrage, zum Zurücksetzen deines Passwortes erhalten.[BR]<p>Unten findest du den Link um dein Passwort zurückzusetzen.</p>",
+    "message": "wir haben deine Anfrage, zum Zurücksetzen deines Passwortes erhalten.[BR]Unten findest du den Link um dein Passwort zurückzusetzen.",
     "note": "Solltest du das nicht veranlasst haben, informiere deinen Vorgesetzeten sofort.",
     "security_note": "Hinweis: Aus sicherheitstechnischen Gründen ist der Link nur 10 Minuten gültig. Nach Ablauf musst du dein Passwort erneut zurücksetzen.",
     "end": "Mit freundlichen Grüßen",

--- a/api/v1/class/i18n/suite/emails/password_reset/snippets_EN.json
+++ b/api/v1/class/i18n/suite/emails/password_reset/snippets_EN.json
@@ -1,7 +1,7 @@
 {
     "subject": "Your request to reset your password",
     "greetings": "Hello",
-    "message": "We have received your request to reset your password.[BR]<p>Below you will find the link to reset your password.</p>",
+    "message": "We have received your request to reset your password.[BR]Below you will find the link to reset your password.",
     "note": "If you have not done so, inform your supervisor immediately.",
     "security_note": "Note: For security reasons, the link is only valid for 10 minutes. After this period, you must reset your password again.",
     "end": "Best regards",

--- a/api/v1/class/i18n/suite/emails/password_reset/snippets_NL.json
+++ b/api/v1/class/i18n/suite/emails/password_reset/snippets_NL.json
@@ -1,7 +1,7 @@
 {
     "subject": "Uw verzoek om uw wachtwoord opnieuw in te stellen",
     "greetings": "Hallo",
-    "message": "we hebben uw verzoek ontvangen om uw wachtwoord opnieuw in te stellen.[BR]<p>Hieronder vindt u de link om uw wachtwoord opnieuw in te stellen.</p>",
+    "message": "we hebben uw verzoek ontvangen om uw wachtwoord opnieuw in te stellen.[BR]Hieronder vindt u de link om uw wachtwoord opnieuw in te stellen.",
     "note": "Als u dit niet zelf heeft gedaan, informeer dan onmiddellijk uw leidinggevende.",
     "security_note": "Opmerking: om veiligheidsredenen is de link slechts 10 minuten geldig. Na het verlopen moet u uw wachtwoord opnieuw instellen.",
     "end": "Met vriendelijke groeten",

--- a/api/v1/class/mails/Mails.arbeit.inc.php
+++ b/api/v1/class/mails/Mails.arbeit.inc.php
@@ -56,14 +56,18 @@ class Mails
     }
 
     $mailContent = $template->render($data);
+    $mailData = $mailContent->toArray();
 
     $ini = Arbeitszeit::get_app_ini()["smtp"];
     if(!$ini["smtp"]){
         Exceptions::error_rep("SMTP disabled, not sending mail.");
         return true;
     } else {
-        EventDispatcherService::get()->dispatch(new SentMailEvent($mailContent->toArray()["to"], $mailContent->toArray()["subject"], $mailContent->toArray()["body"]), SentMailEvent::NAME);
-        return self::$provider->send($mailContent->toArray());
+        $user = Benutzer::get_user($mailData["username"]);
+        $email = is_array($user) && isset($user["email"]) ? $user["email"] : ($data["email"] ?? "");
+
+        EventDispatcherService::get()->dispatch(new SentMailEvent($mailData["username"], $email, $templateName), SentMailEvent::NAME);
+        return self::$provider->send($mailData);
     }
 }
 

--- a/api/v1/class/plugins/PluginBuilder.plugins.arbeit.inc.php
+++ b/api/v1/class/plugins/PluginBuilder.plugins.arbeit.inc.php
@@ -256,7 +256,13 @@ namespace Arbeitszeit {
                 $requiredPermission = $permissions['nav_permissions'][$viewName]; 
                 $this->logger("{$la} Required permission for view '{$viewName}': '{$requiredPermission}'");
                 if ($requiredPermission === 5) {
-                    $this->logger("{$la} View '{$viewName}' has permission level 5 (internal placeholder). Access denied.");
+                    if ($userPermissions === $adminLevel) {
+                        $this->logger("{$la} View '{$viewName}' has permission level 5 (internal placeholder). Access allowed if admin.");
+                        return true;
+                    } else {
+                        $this->logger("{$la} View '{$viewName}' has permission level 5 (internal placeholder). Access denied for non-admin user '{$user}'.");
+                        return false;
+                    }
                     return false;
                 }
 

--- a/api/v1/class/plugins/plugins/nfcclock/views/routes/settings.php
+++ b/api/v1/class/plugins/plugins/nfcclock/views/routes/settings.php
@@ -11,6 +11,7 @@ use NFClogin\NFClogin;
 use NFCClock\NFCClock;
 $arbeit = new Arbeitszeit;
 $main = new NFCClock;
+$statusMessages = $arbeit->statusMessages();
 
 // initial NFC login / session handling
 if (!empty($_SESSION['nfcclock_user'])) {

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "TimeTrack is a PHP-written time recording tool for small businesses",
   "type": "software",
   "license": "GNU GPL",
-  "version": "8.7.1",
+  "version": "8.7.2",
   "authors": [
     {
       "name": "Bryan Boehnke-Avan",

--- a/suite/projects/item.php
+++ b/suite/projects/item.php
@@ -55,8 +55,8 @@ $worktimes = $arbeit->projects()->getUserProjectWorktimes($project["id"]);
                 </thead>
                 <tbody>
                     <?php foreach($worktimes as $w): ?>
-                        <tr>
-                            <td><?= $arbeit->i18n()->sanitizeOutput($w["user"] ?? "-"); ?></td>
+                        <tr> 
+                            <td><?= $arbeit->i18n()->sanitizeOutput($arbeit->benutzer()->get_user_from_id($w["user"])["name"] ?? "-"); ?></td>
                             <td><?= $arbeit->i18n()->sanitizeOutput($w["hours"] ?? "-"); ?></td>
                             <td><?= $arbeit->i18n()->sanitizeOutput($w["date"] ?? "-"); ?></td>
                         </tr>


### PR DESCRIPTION
## 8.7.2

> This will be the last release for the 8.x branch. The next release will be 9.0 which will include a new feature called `Worktime Governance` which will allow to set rules for worktimes, e.g. maximum worktime per day, minimum break time, etc. The feature is still in development and will be released as soon as it is ready.
* Fixed an issue with the password reset email that would not display correctly.
* Fixed incorrect use of the `SentEmail` event for any sent emails.
* Fixed an issue with the `PluginHub` which caused certain pages to be blocked. Now admins can access these again. This issue only affected the `userdetail` plugin.
* Fixed an issue with the `nfcclock` plugin which caused it to not fire any events.
* The items page for project items now displays the user's name instead of the ID.